### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In order to share the keychain data across different applications enable Keychai
         NSLog(@"Failed to delete!");
     }
 
-If you don't want to use Cocoapods you can just grab the JNKeychain.h and JNKeychain.m files and put them somewhere in your project.
+If you don't want to use CocoaPods you can just grab the JNKeychain.h and JNKeychain.m files and put them somewhere in your project.
 
 ## Requirements
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
